### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,6 @@
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/abulo/ratel/security/code-scanning/9](https://github.com/abulo/ratel/security/code-scanning/9)

In general, the fix is to explicitly define a `permissions` block that limits the `GITHUB_TOKEN` to the minimal scopes required by this workflow. Because the job only needs to check out the repository and run Go/module commands, it primarily requires read access to repository contents. It does not need to write to the repository or manage issues, pull requests, or other resources.

The single best way to fix this, without changing existing behavior, is to add a `permissions` block at the workflow root level (so it applies to all jobs) with `contents: read`. This matches the minimal starting point suggested by CodeQL and GitHub’s documentation. Place this block right after the `name: Go` line and before the `on:` block to keep the file clear and conventional:

```yaml
name: Go
permissions:
  contents: read

on:
  ...
```

No additional methods, imports, or definitions are required; the change is entirely within the workflow YAML. If in the future the workflow adds steps that need more privileges (e.g., commenting on PRs), those specific scopes can be added to this `permissions` block or a job-level override.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
